### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/staging-prod.yml
+++ b/.github/workflows/staging-prod.yml
@@ -19,7 +19,7 @@ jobs:
           echo "setting variables"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           username: tattletech
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore